### PR TITLE
iterator: fix start after db end handling

### DIFF
--- a/memdown.js
+++ b/memdown.js
@@ -24,10 +24,10 @@ function MemIterator (db, options) {
         break
       }
     }
+    if (this._pos == null && !this._reverse) this._pos = -1
   }
 
   if (!options.start || !this._pos)
-  //else
     this._pos = this._reverse ? this.db._keys.length - 1 : 0
 }
 


### PR DESCRIPTION
This fixes memdown for the new test I added to abstract-leveldown: https://github.com/rvagg/node-abstract-leveldown/commit/4319e5d3d8da69ab072db78708cfb00b83e253b6

Without this fix a iterator that starts after the db end and isn't reversed will emit everything instead of nothing.
