### PR TITLE
Add basic insert/delete benchmarks

### DIFF
--- a/benchmarks/delete.js
+++ b/benchmarks/delete.js
@@ -1,0 +1,58 @@
+// run with: node delete.js
+
+// Benchmarks different deletion strategies (for deleting many keys)
+
+var assert = require('assert'),
+    bench = require('bench')
+
+var NUM_KEYS = 1e3
+
+exports.compare = {
+  'binary delete': function() {
+    deleteKeys(binaryDelete)
+  },
+  'linear delete': function() {
+    deleteKeys(linearDelete)
+  },
+}
+
+bench.runMain()
+
+function deleteKeys(deleteFn) {
+  var keys = [], i, key
+  for (i = 0; i < NUM_KEYS; i++) {
+    keys.push(Math.random().toString(36).slice(2))
+  }
+  keys.sort()
+  for (i = 0; i < NUM_KEYS; i++) {
+    key = keys[Math.round(Math.random() * (keys.length - 1))]
+    deleteFn(keys, key)
+  }
+  assert.equal(keys.length, 0)
+}
+
+// Reflects the key deletion strategy added in #2078b40cd
+function binaryDelete(keys, key) {
+  var ix = sortedIndexOf(keys, key)
+  if (keys[ix] == key)
+    keys.splice(ix, 1)
+}
+
+// Reflects the key deletion strategy prior to #2078b40cd
+function linearDelete(keys, key) {
+  for (var i = 0; i < keys.length; i++) {
+    if (keys[i] == key) {
+      keys.splice(i, 1)
+      break
+    }
+  }
+}
+
+function sortedIndexOf(arr, item) {
+  var low = 0, high = arr.length, mid
+  while (low < high) {
+    mid = (low + high) >>> 1
+    arr[mid] < item ? low = mid + 1 : high = mid
+  }
+  return low
+}

--- a/benchmarks/insert.js
+++ b/benchmarks/insert.js
@@ -1,0 +1,56 @@
+// run with: node insert.js
+
+// Benchmarks different insertion strategies (for inserting many keys)
+
+var assert = require('assert'),
+    bench = require('bench')
+
+var NUM_KEYS = 1e3, INSERT_EXISTING_CHANCE = 0.1
+
+exports.compare = {
+  'binary insert': function() {
+    insertKeys(binaryInsert)
+  },
+  'push() + sort()': function() {
+    insertKeys(pushAndSort)
+  },
+}
+
+bench.runMain()
+
+function insertKeys(insertFn) {
+  var keys = [], keySet = {}, i, key
+  for (i = 0; i < NUM_KEYS; i++) {
+    // Allow a certain portion of inserts to use keys that already exist (ie, put existing)
+    key = Math.random() < INSERT_EXISTING_CHANCE && keys.length ?
+      keys[Math.round(Math.random() * (keys.length - 1))] : Math.random().toString(36).slice(2)
+    keySet[key] = true
+    insertFn(keys, key)
+  }
+  // Ensure all the keys are there and sorted
+  assert.deepEqual(keys, Object.keys(keySet).sort())
+}
+
+// Reflects the key insertion strategy added in #2078b40cd
+function binaryInsert(keys, key) {
+  var ix = sortedIndexOf(keys, key)
+  if (keys[ix] != key)
+    keys.splice(ix, 0, key)
+}
+
+// Reflects the key insertion strategy prior to #2078b40cd
+function pushAndSort(keys, key) {
+  if (keys.indexOf(key) == -1) {
+    keys.push(key)
+    keys.sort()
+  }
+}
+
+function sortedIndexOf(arr, item) {
+  var low = 0, high = arr.length, mid
+  while (low < high) {
+    mid = (low + high) >>> 1
+    arr[mid] < item ? low = mid + 1 : high = mid
+  }
+  return low
+}

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   },
   "devDependencies": {
     "tape": "*",
-    "rimraf": "*"
+    "rimraf": "*",
+    "bench": "*"
   },
   "browser": {
     "rimraf": false


### PR DESCRIPTION
These don’t actually benchmark MemDOWN directly, but rather compare different strategies for inserting/deleting keys. (I'm not exactly sure as to the best strategy for comparing different versions of MemDOWN - just keep a running tally of benchmark results I guess?)

I figured `bench` was probably a bit more lightweight than any of the other options (less deps). Running these benchmarks on my MacBook Air I get:

```
Scores: (bigger is better)

binary insert
Raw:
 > 0.2933411557641537
 > 0.3137747097583935
 > 0.31446540880503143
 > 0.3082614056720099
Average (mean) 0.30746066999989713

push() + sort()
Raw:
 > 0.0022455308322610924
 > 0.0023219257123087604
 > 0.0023006911276147353
 > 0.002307960386167932
Average (mean) 0.00229402701458813

Winner: binary insert
Compared with next highest (push() + sort()), it's:
99.25% faster
134.03 times as fast
2.13 order(s) of magnitude faster
A LOT FASTER
```

and

```
Scores: (bigger is better)

binary delete
Raw:
 > 0.5425935973955507
 > 0.5339028296849974
 > 0.5136106831022085
 > 0.4975124378109453
Average (mean) 0.5219048869984254

linear delete
Raw:
 > 0.15087507543753773
 > 0.14490653528474134
 > 0.14575134819997085
 > 0.14863258026159334
Average (mean) 0.1475413847959608

Winner: binary delete
Compared with next highest (linear delete), it's:
71.73% faster
3.54 times as fast
0.55 order(s) of magnitude faster
QUITE A BIT FASTER
```
