### PR TITLE
Implement destroy(), use global db store

### DIFF
--- a/memdown.js
+++ b/memdown.js
@@ -4,9 +4,21 @@ var inherits          = require('inherits')
   , ltgt              = require('ltgt')
   , noop              = function () {}
   , setImmediate      = global.setImmediate || process.nextTick
+  , globalStore       = {}
+
+
 
 function toKey (key) {
   return typeof key == 'string' ? '$' + key : JSON.stringify(key)
+}
+
+function getOrCreateDatabaseFromGlobal(name) {
+  var key = toKey(name)
+    , db = globalStore[key]
+  if (!db) {
+    db = globalStore[key] = {store: {}, keys: []}
+  }
+  return db
 }
 
 function sortedIndexOf (arr, item) {
@@ -61,9 +73,10 @@ function MemDOWN (location) {
     return new MemDOWN(location)
 
   AbstractLevelDOWN.call(this, typeof location == 'string' ? location : '')
-  this._store = {}
-  this._keys  = []
-  this._len = 0;
+  
+  var db = getOrCreateDatabaseFromGlobal(location)
+  this._store = db.store
+  this._keys = db.keys
 }
 
 inherits(MemDOWN, AbstractLevelDOWN)
@@ -75,9 +88,8 @@ MemDOWN.prototype._open = function (options, callback) {
 
 MemDOWN.prototype._put = function (key, value, options, callback) {
   var ix = sortedIndexOf(this._keys, key)
-  if (ix >= this._len || this._keys[ix] != key) {
+  if (ix >= this._keys.length || this._keys[ix] != key) {
     this._keys.splice(ix, 0, key)
-    this._len++;
   }
   key = toKey(key) // safety, to avoid key='__proto__'-type skullduggery 
   this._store[key] = value
@@ -101,7 +113,6 @@ MemDOWN.prototype._del = function (key, options, callback) {
   var ix = sortedIndexOf(this._keys, key)
   if (this._keys[ix] == key) {
     this._keys.splice(ix, 1)
-    this._len--;
   }
   delete this._store[toKey(key)]
   setImmediate(callback)
@@ -139,6 +150,18 @@ MemDOWN.prototype._iterator = function (options) {
 
 MemDOWN.prototype._isBuffer = function (obj) {
   return Buffer.isBuffer(obj)
+}
+
+MemDOWN.destroy = function (name, callback) {
+  var key = toKey(name)
+    , db = globalStore[key]
+  if (db) {
+    while (db.keys.length) {
+      delete db.store[toKey(db.keys.pop())]
+    }
+  }
+  delete globalStore[key]
+  setImmediate(callback)
 }
 
 module.exports = MemDOWN

--- a/test.js
+++ b/test.js
@@ -28,6 +28,43 @@ require('abstract-leveldown/abstract/iterator-test').all(MemDOWN, test, testComm
 
 require('abstract-leveldown/abstract/ranges-test').all(MemDOWN, test, testCommon)
 
+
+//
+// TODO: destroy() test copied from localstorage-down
+// https://github.com/pouchdb/pouchdb/blob/master/lib/adapters/leveldb.js#L1019
+// move this test to abstract-leveldown
+// 
+
+test('test .destroy', function (t) {
+  var db = new MemDOWN('destroy-test')
+  var db2 = new MemDOWN('other-db')
+  db2.put('key2', 'value2', function (err) {
+    t.notOk(err, 'no error')
+    db.put('key', 'value', function (err) {
+      t.notOk(err, 'no error')
+      db.get('key', {asBuffer: false}, function (err, value) {
+        t.notOk(err, 'no error')
+        t.equal(value, 'value', 'should have value')
+        db.close(function (err) {
+          t.notOk(err, 'no error')
+          MemDOWN.destroy('destroy-test', function (err) {
+            t.notOk(err, 'no error')
+            var db3 = new MemDOWN('destroy-test')
+            db3.get('key', function (err, value) {
+              t.ok(err, 'key is not there')
+              db2.get('key2', {asBuffer: false}, function (err, value) {
+                t.notOk(err, 'no error')
+                t.equal(value, 'value2', 'should have value2')
+                t.end()
+              })
+            })
+          })
+        })
+      })
+    })
+  })
+})
+
 test('unsorted entry, sorted iterator', function (t) {
   var db = new MemDOWN('foo')
     , noop = function () {}
@@ -59,7 +96,7 @@ test('unsorted entry, sorted iterator', function (t) {
 })
 
 test('reading while putting', function (t) {
-  var db = new MemDOWN('foo')
+  var db = new MemDOWN('foo2')
     , noop = function () {}
     , iterator
   db.open(noop)
@@ -81,7 +118,7 @@ test('reading while putting', function (t) {
 
 
 test('reading while deleting', function (t) {
-  var db = new MemDOWN('foo')
+  var db = new MemDOWN('foo3')
     , noop = function () {}
     , iterator
   db.open(noop)
@@ -103,7 +140,7 @@ test('reading while deleting', function (t) {
 })
 
 test('reverse ranges', function(t) {
-  var db = new MemDOWN('foo')
+  var db = new MemDOWN('foo4')
     , noop = function () {}
     , iterator
   db.open(noop)


### PR DESCRIPTION
Fixes #22.

There's now a global store that keeps track of all memdown databases, keyed by location. so if you do:

``` js
var db1 = new MemDOWN('foo')
var db2 = new MemDOWN('foo')
```

then both `db1` and `db2` will contain the same data.

I also added a destroy test here, rather than in abstract-leveldown, because memdown isn't even passing the latest abstract-leveldown tests. If you want to see these tests pass at 100%, we're going to need to peg abstract-leveldown to v0.12.3 due to the snapshot test.
