### PR TITLE
peg abstract-leveldown to skip snapshot test

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/rvagg/node-memdown.git"
   },
   "dependencies": {
-    "abstract-leveldown": "~0.12.2",
+    "abstract-leveldown": "0.12.3",
     "inherits": "~2.0.1",
     "ltgt": "~1.0.2"
   },


### PR DESCRIPTION
In light of https://github.com/rvagg/memdown/pull/23 and https://github.com/rvagg/memdown/pull/21 I would really rather we just peg abstract-leveldown to a working version and then work form there.
