### PR TITLE
add ability to clear global cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,15 @@ Running our example gives:
 Show's over folks!
 ```
 
+Global Store
+---
+
+Even though it's in memory the location parameter does do something.  Memdown
+has a global cache which it uses to save databases by the path string.  You may
+clear this via the Memdown.clearGlobalStore function. By default it doesn't delete
+the store but replaces it with a new one, open instance of memdown will not be affected. `clearGlobalStore` takes a single parameter, which if truthy clears the store strictly by deleting each individual key.  If there is an in use instance of memdown this will
+cause the in use memdown instance to error.
+
 ## Licence
 
 MemDOWN is Copyright (c) 2013-2015 Rod Vagg [@rvagg](https://twitter.com/rvagg) and licensed under the MIT licence. All rights not explicitly granted in the MIT license are reserved. See the included LICENSE file for more details.

--- a/memdown.js
+++ b/memdown.js
@@ -41,38 +41,38 @@ function MemIterator (db, options) {
   this._reverse   = options.reverse
   this._options = options
   this._done = 0
-  
+
   if (!this._reverse) {
     this._incr = 'next';
     this._start = ltgt.lowerBound(options);
     this._end = ltgt.upperBound(options)
-    
+
     if (typeof this._start === 'undefined')
       this._tree = tree.begin;
     else if (ltgt.lowerBoundInclusive(options))
       this._tree = tree.ge(this._start);
     else
       this._tree = tree.gt(this._start);
-    
+
     if (this._end) {
       if (ltgt.upperBoundInclusive(options))
         this._test = lte
       else
         this._test = lt
     }
-  
+
   } else {
     this._incr = 'prev';
     this._start = ltgt.upperBound(options)
     this._end = ltgt.lowerBound(options)
-  
+
     if (typeof this._start === 'undefined')
       this._tree = tree.end;
     else if (ltgt.upperBoundInclusive(options))
       this._tree = tree.le(this._start)
     else
       this._tree = tree.lt(this._start)
-  
+
     if (this._end) {
       if (ltgt.lowerBoundInclusive(options))
         this._test = gte
@@ -128,6 +128,16 @@ function MemDOWN (location) {
   this._store[this._location] = this._store[this._location] || createRBT()
 }
 
+MemDOWN.clearGlobalStore = function (strict) {
+  if (strict) {
+    Object.keys(globalStore).forEach(function (key) {
+      delete globalStore[key];
+    })
+  } else {
+    globalStore = {}
+  }
+}
+
 inherits(MemDOWN, AbstractLevelDOWN)
 
 MemDOWN.prototype._open = function (options, callback) {
@@ -152,7 +162,7 @@ MemDOWN.prototype._get = function (key, options, callback) {
 
   if (options.asBuffer !== false && !this._isBuffer(value))
     value = new Buffer(String(value))
-  
+
   setImmediate(function callNext () {
     callback(null, value)
   })
@@ -175,12 +185,12 @@ MemDOWN.prototype._batch = function (array, options, callback) {
   while (++i < len) {
     if (!array[i])
       continue;
-    
+
     key = this._isBuffer(array[i].key) ? array[i].key : String(array[i].key)
     err = this._checkKey(key, 'key')
     if (err)
       return setImmediate(function errorCall() { callback(err) })
-    
+
     tree = tree.remove(array[i].key)
     // we always remove as insert doesn't replace
 
@@ -194,9 +204,9 @@ MemDOWN.prototype._batch = function (array, options, callback) {
 
       tree = tree.insert(key, value)
     }
-  
+
   }
-  
+
   this._store[this._location] = tree;
 
   setImmediate(callback)


### PR DESCRIPTION
two versions of it, normal which just empties it so new databases will get a fresh copy while current databases will use the old one and a strict mode that deletes everything out of it in order to clear out any cached references to it.