### PR TITLE
allow empty value in batch

### DIFF
--- a/memdown.js
+++ b/memdown.js
@@ -204,7 +204,8 @@ MemDOWN.prototype._batch = function (array, options, callback) {
 
     if (array[i].type === 'put') {
       value = this._isBuffer(array[i].value) ? array[i].value : String(array[i].value)
-      err = this._checkKey(value, 'value')
+      if (value === null || value === undefined)
+        err = new Error('value cannot be `null` or `undefined`')
 
       if (err)
         return setImmediate(function errorCall() { callback(err) })


### PR DESCRIPTION
This PR allows for empty values in batches. Regular leveldown supports this and this is already supported using `.put`.