### PR TITLE
use immediate instead of setImmediate

### DIFF
--- a/memdown.js
+++ b/memdown.js
@@ -2,7 +2,7 @@ var inherits          = require('inherits')
   , AbstractLevelDOWN = require('abstract-leveldown').AbstractLevelDOWN
   , AbstractIterator  = require('abstract-leveldown').AbstractIterator
   , ltgt              = require('ltgt')
-  , setImmediate      = global.setImmediate || process.nextTick
+  , setImmediate      = require('immediate')
   , createRBT = require('functional-red-black-tree')
   , globalStore       = {}
 

--- a/package.json
+++ b/package.json
@@ -21,10 +21,11 @@
     "url": "https://github.com/Level/memdown.git"
   },
   "dependencies": {
-    "inherits": "~2.0.1",
-    "ltgt": "~1.0.2",
+    "abstract-leveldown": "2.4.1",
     "functional-red-black-tree": "^1.0.1",
-    "abstract-leveldown": "2.4.1"
+    "immediate": "^3.2.3",
+    "inherits": "~2.0.1",
+    "ltgt": "~1.0.2"
   },
   "devDependencies": {
     "bench": "*",


### PR DESCRIPTION
Using setTimeout is slower than using `immediate`, which defaults to using MutationObserver to make microtasks. In the browser, I notice a lot of time is just spent idle because it uses `setTimeout`. So we should avoid that.