### PR TITLE
use abstract-leveldown-pouchdb@2.4.3

### DIFF
--- a/memdown.js
+++ b/memdown.js
@@ -1,6 +1,6 @@
 var inherits          = require('inherits')
-  , AbstractLevelDOWN = require('abstract-leveldown').AbstractLevelDOWN
-  , AbstractIterator  = require('abstract-leveldown').AbstractIterator
+  , AbstractLevelDOWN = require('abstract-leveldown-pouchdb').AbstractLevelDOWN
+  , AbstractIterator  = require('abstract-leveldown-pouchdb').AbstractIterator
   , ltgt              = require('ltgt')
   , createRBT = require('functional-red-black-tree')
   , globalStore       = {}

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "inherits": "~2.0.1",
     "ltgt": "~1.0.2",
     "functional-red-black-tree": "^1.0.1",
-    "abstract-leveldown": "2.4.1"
+    "abstract-leveldown-pouchdb": "^2.4.3"
   },
   "devDependencies": {
     "bench": "*",

--- a/test.js
+++ b/test.js
@@ -1,5 +1,5 @@
 var test       = require('tape')
-  , testCommon = require('abstract-leveldown/testCommon')
+  , testCommon = require('abstract-leveldown-pouchdb/testCommon')
   , MemDOWN    = require('./')
   //, AbstractIterator = require('./').AbstractIterator
   , testBuffer = require('./testdata_b64')
@@ -7,33 +7,33 @@ var test       = require('tape')
 
 /*** compatibility with basic LevelDOWN API ***/
 
-// meh require('abstract-leveldown/abstract/leveldown-test').args(MemDOWN, test, testCommon)
+// meh require('abstract-leveldown-pouchdb/abstract/leveldown-test').args(MemDOWN, test, testCommon)
 
-require('abstract-leveldown/abstract/open-test').args(MemDOWN, test, testCommon)
-require('abstract-leveldown/abstract/open-test').open(MemDOWN, test, testCommon)
+require('abstract-leveldown-pouchdb/abstract/open-test').args(MemDOWN, test, testCommon)
+require('abstract-leveldown-pouchdb/abstract/open-test').open(MemDOWN, test, testCommon)
 
-require('abstract-leveldown/abstract/del-test').all(MemDOWN, test, testCommon)
+require('abstract-leveldown-pouchdb/abstract/del-test').all(MemDOWN, test, testCommon)
 
-require('abstract-leveldown/abstract/get-test').all(MemDOWN, test, testCommon)
+require('abstract-leveldown-pouchdb/abstract/get-test').all(MemDOWN, test, testCommon)
 
-require('abstract-leveldown/abstract/put-test').all(MemDOWN, test, testCommon)
+require('abstract-leveldown-pouchdb/abstract/put-test').all(MemDOWN, test, testCommon)
 
-require('abstract-leveldown/abstract/put-get-del-test').all(MemDOWN, test, testCommon, testBuffer)
+require('abstract-leveldown-pouchdb/abstract/put-get-del-test').all(MemDOWN, test, testCommon, testBuffer)
 
-require('abstract-leveldown/abstract/batch-test').all(MemDOWN, test, testCommon)
-require('abstract-leveldown/abstract/chained-batch-test').all(MemDOWN, test, testCommon)
+require('abstract-leveldown-pouchdb/abstract/batch-test').all(MemDOWN, test, testCommon)
+require('abstract-leveldown-pouchdb/abstract/chained-batch-test').all(MemDOWN, test, testCommon)
 
-require('abstract-leveldown/abstract/close-test').close(MemDOWN, test, testCommon)
+require('abstract-leveldown-pouchdb/abstract/close-test').close(MemDOWN, test, testCommon)
 
-require('abstract-leveldown/abstract/iterator-test').all(MemDOWN, test, testCommon)
+require('abstract-leveldown-pouchdb/abstract/iterator-test').all(MemDOWN, test, testCommon)
 
-require('abstract-leveldown/abstract/ranges-test').all(MemDOWN, test, testCommon)
+require('abstract-leveldown-pouchdb/abstract/ranges-test').all(MemDOWN, test, testCommon)
 
 
 //
 // TODO: destroy() test copied from localstorage-down
 // https://github.com/pouchdb/pouchdb/blob/master/lib/adapters/leveldb.js#L1019
-// move this test to abstract-leveldown
+// move this test to abstract-leveldown-pouchdb
 //
 
 test('test .destroy', function (t) {


### PR DESCRIPTION
This is a perf improvement because 2.4.3 avoids allocating an extra NotFoundError. Also this puts us on a fork of `abstract-leveldown`, which I'm not super happy about, but I don't see a way around it without expending a lot of energy to update to abstract-leveldown 2.6.0 so I preferred to fork.