### PR TITLE
Don't block render with process.nextTick polyfill.

### DIFF
--- a/memdown.js
+++ b/memdown.js
@@ -4,8 +4,26 @@ var inherits          = require('inherits')
   , ltgt              = require('ltgt')
   , createRBT = require('functional-red-black-tree')
   , globalStore       = {}
+  , queue             = []
+  , timeout
 /* istanbul ignore next */
-var setImmediate = global.setImmediate || process.nextTick
+var setImmediate = global.setImmediate || _nextTick
+
+let _tick = () => {
+  if (queue.length)
+    queue.shift()()
+
+  if (queue.length)
+    timeout = setTimeout(_tick, 0)
+  else
+    timeout = false
+}
+
+function _nextTick(cb) {
+  queue.push(cb)
+  if (!timeout)
+    timeout = setTimeout(_tick, 0)
+}
 
 function gt(value) {
   return ltgt.compare(value, this._end) > 0


### PR DESCRIPTION
If you slam the browserify process.nextTicket polyfill it appears to block UI rendering, scrolling, etc.

These methods ensure that no more than one callback comes off the event queue at a time. I'm running it locally and it completely fixed an issue I had. 

I tried to match the coding style in the file but I'm not 100% sure I nailed it.