### PR TITLE
Remove global store

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@
 `levelup` allows you to pass a `db` option to its constructor. This overrides the default `leveldown` store.
 
 ```js
-// Note that if multiple instances point to the same location,
-// the db will be shared, but only per process.
 var levelup = require('levelup')
 var db = levelup('/some/location', { db: require('memdown') })
 
@@ -42,37 +40,6 @@ Browser support
 [![Sauce Test Status](https://saucelabs.com/browser-matrix/level-ci.svg)](https://saucelabs.com/u/level-ci)
 
 `memdown` requires a ES5-capable browser. If you're using one that's isn't (e.g. PhantomJS, Android < 4.4, IE < 10) then you will need [es5-shim](https://github.com/es-shims/es5-shim).
-
-Global Store
----
-
-Even though it's in memory, the location parameter does do something. `memdown`
-has a global cache, which it uses to save databases by the path string.
-
-So for instance if you create these two instances:
-
-```js
-var db1 = levelup('foo', {db: require('memdown')});
-var db2 = levelup('foo', {db: require('memdown')});
-```
-
-Then they will actually share the same data, because the `'foo'` string is the same.
-
-You may clear this global store using `memdown.clearGlobalStore()`:
-
-```js
-require('memdown').clearGlobalStore();
-```
-
-By default, it doesn't delete the store but replaces it with a new one, so the open instance of `memdown` will not be affected.
-
-`clearGlobalStore` takes a single parameter, which if truthy clears the store strictly by deleting each individual key:
-
-```js
-require('memdown').clearGlobalStore(true); // delete each individual key
-```
-
-If you are using `memdown` somewhere else while simultaneously clearing the global store in this way, then it may throw an error or cause unexpected results.
 
 Test
 ----

--- a/memdown.d.ts
+++ b/memdown.d.ts
@@ -5,8 +5,8 @@ export interface MemDown<K=any, V=any>
 }
 
 interface MemDownConstructor {
-  new <K=any, V=any>(location: string): MemDown<K, V>;
-  <K=any, V=any>(location: string): MemDown<K, V>;
+  new <K=any, V=any>(): MemDown<K, V>;
+  <K=any, V=any>(): MemDown<K, V>;
 }
 
 export interface MemDownGetOptions {
@@ -17,9 +17,6 @@ export interface MemDownIteratorOptions {
   keyAsBuffer?: boolean;
   valueAsBuffer?: boolean;
 }
-
-export function clearGlobalStore(strict?: boolean);
-export function destroy(location: string, cb: () => void): void;
 
 declare const MemDown: MemDownConstructor;
 export default MemDown;

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "safe-buffer": "~5.1.1"
   },
   "devDependencies": {
+    "@types/node": "~8.0.47",
     "bench": "*",
     "faucet": "*",
     "istanbul": "^0.4.2",
@@ -38,6 +39,8 @@
     "rimraf": "*",
     "standard": "^10.0.3",
     "tape": "*",
+    "ts-node": "~3.3.0",
+    "typescript": "~2.6.1",
     "zuul": "github:vweevers/zuul#custom-loopback-hostname"
   },
   "browser": {
@@ -45,7 +48,8 @@
     "./immediate.js": "./immediate-browser.js"
   },
   "scripts": {
-    "test": "standard && node ./test.js --stderr | faucet",
+    "test": "standard && node test.js --stderr | faucet && npm run test-ts",
+    "test-ts": "ts-node --no-cache test.js | faucet",
     "test-browsers": "zuul --browser-retries 2 --sauce-connect --concurrency 5 --loopback zuul.local --no-coverage ./test.js",
     "test-browser-local": "zuul --ui tape --no-coverage --local 9000 ./test.js",
     "coverage": "istanbul cover -i memdown.js ./node_modules/.bin/tape ./test.js && istanbul check-coverage --lines 90 --function 80 --statements 90 --branches 80",

--- a/test.js
+++ b/test.js
@@ -31,57 +31,8 @@ require('abstract-leveldown/abstract/iterator-test').all(MemDOWN, test, testComm
 
 require('abstract-leveldown/abstract/ranges-test').all(MemDOWN, test, testCommon)
 
-//
-// TODO: destroy() test copied from localstorage-down
-// https://github.com/pouchdb/pouchdb/blob/master/lib/adapters/leveldb.js#L1019
-// move this test to abstract-leveldown
-//
-
-test('test .destroy', function (t) {
-  var db = new MemDOWN('destroy-test')
-  var db2 = new MemDOWN('other-db')
-
-  db2.put('key2', 'value2', function (err) {
-    t.notOk(err, 'no error')
-
-    db.put('key', 'value', function (err) {
-      t.notOk(err, 'no error')
-
-      db.get('key', { asBuffer: false }, function (err, value) {
-        t.notOk(err, 'no error')
-        t.equal(value, 'value', 'should have value')
-
-        db.close(function (err) {
-          t.notOk(err, 'no error')
-
-          db2.close(function (err) {
-            t.notOk(err, 'no error')
-
-            MemDOWN.destroy('destroy-test', function (err) {
-              t.notOk(err, 'no error')
-
-              var db3 = new MemDOWN('destroy-test')
-              var db4 = new MemDOWN('other-db')
-
-              db3.get('key', function (err, value) {
-                t.ok(err, 'key is not there')
-
-                db4.get('key2', { asBuffer: false }, function (err, value) {
-                  t.notOk(err, 'no error')
-                  t.equal(value, 'value2', 'should have value2')
-                  t.end()
-                })
-              })
-            })
-          })
-        })
-      })
-    })
-  })
-})
-
 test('unsorted entry, sorted iterator', function (t) {
-  var db = new MemDOWN('foo')
+  var db = new MemDOWN()
 
   db.open(noop)
 
@@ -122,7 +73,7 @@ test('unsorted entry, sorted iterator', function (t) {
 })
 
 test('reading while putting', function (t) {
-  var db = new MemDOWN('foo2')
+  var db = new MemDOWN()
 
   db.open(noop)
 
@@ -149,7 +100,7 @@ test('reading while putting', function (t) {
 })
 
 test('reading while deleting', function (t) {
-  var db = new MemDOWN('foo3')
+  var db = new MemDOWN()
 
   db.open(noop)
 
@@ -177,34 +128,9 @@ test('reading while deleting', function (t) {
 })
 
 test('reverse ranges', function (t) {
-  var db = new MemDOWN('foo4')
-
-  db.open(noop)
-
-  db.put('a', 'A', noop)
-  db.put('c', 'C', noop)
-
-  var iterator = db.iterator({
-    keyAsBuffer: false,
-    valueAsBuffer: false,
-    start: 'b',
-    reverse: true
-  })
-
-  iterator.next(function (err, key, value) {
-    t.ifError(err, 'no next error')
-    t.equal(key, 'a')
-    t.equal(value, 'A')
-    t.end()
-  })
-})
-
-test('no location', function (t) {
   var db = new MemDOWN()
 
-  db.open(function (err) {
-    t.error(err, 'opens correctly')
-  })
+  db.open(noop)
 
   db.put('a', 'A', noop)
   db.put('c', 'C', noop)
@@ -347,7 +273,7 @@ test('empty value in batch', function (t) {
 })
 
 test('empty buffer key in batch', function (t) {
-  var db = new MemDOWN('empty-buffer')
+  var db = new MemDOWN()
 
   db.open(function (err) {
     t.error(err, 'opens correctly')
@@ -364,7 +290,7 @@ test('empty buffer key in batch', function (t) {
 })
 
 test('buffer key in batch', function (t) {
-  var db = new MemDOWN('buffer-key')
+  var db = new MemDOWN()
 
   db.open(function (err) {
     t.error(err, 'opens correctly')
@@ -386,7 +312,7 @@ test('buffer key in batch', function (t) {
 })
 
 test('array with holes in batch()', function (t) {
-  var db = new MemDOWN('holey')
+  var db = new MemDOWN()
 
   db.open(function (err) {
     t.error(err, 'opens correctly')
@@ -438,126 +364,6 @@ test('put multiple times', function (t) {
       db.get('key', { asBuffer: false }, function (err, val) {
         t.error(err, 'no error')
         t.same(val, 'val2')
-      })
-    })
-  })
-})
-
-test('global store', function (t) {
-  var db = new MemDOWN('foobar')
-
-  var noerr = function (err) {
-    t.error(err, 'opens correctly')
-  }
-
-  db.open(noerr)
-
-  db.put('key', 'val', function (err) {
-    t.error(err, 'no error')
-    db.get('key', { asBuffer: false }, function (err, val) {
-      t.error(err, 'no error')
-      t.same(val, 'val')
-
-      var db2 = new MemDOWN('foobar')
-      db2.open(noerr)
-
-      db2.get('key', { asBuffer: false }, function (err, val) {
-        t.error(err, 'no error')
-        t.same(val, 'val')
-
-        MemDOWN.clearGlobalStore()
-
-        var db3 = new MemDOWN('foobar')
-        db3.open(noerr)
-
-        db3.get('key', { asBuffer: false }, function (err) {
-          t.ok(err, 'should be an error')
-          t.end()
-        })
-      })
-    })
-  })
-})
-
-test('global store, strict', function (t) {
-  var db = new MemDOWN('foobar')
-
-  var noerr = function (err) {
-    t.error(err, 'opens correctly')
-  }
-
-  db.open(noerr)
-
-  db.put('key', 'val', function (err) {
-    t.error(err, 'no error')
-
-    db.get('key', { asBuffer: false }, function (err, val) {
-      t.error(err, 'no error')
-      t.same(val, 'val')
-
-      var db2 = new MemDOWN('foobar')
-      db2.open(noerr)
-
-      db2.get('key', { asBuffer: false }, function (err, val) {
-        t.error(err, 'no error')
-        t.same(val, 'val')
-
-        MemDOWN.clearGlobalStore(true)
-
-        var db3 = new MemDOWN('foobar')
-        db3.open(noerr)
-
-        db3.get('key', { asBuffer: false }, function (err) {
-          t.ok(err, 'should be an error')
-          t.end()
-        })
-      })
-    })
-  })
-})
-
-test('call .destroy twice', function (t) {
-  var db = new MemDOWN('destroy-test')
-  var db2 = new MemDOWN('other-db')
-
-  db2.put('key2', 'value2', function (err) {
-    t.notOk(err, 'no error')
-
-    db.put('key', 'value', function (err) {
-      t.notOk(err, 'no error')
-
-      db.get('key', { asBuffer: false }, function (err, value) {
-        t.notOk(err, 'no error')
-        t.equal(value, 'value', 'should have value')
-
-        db.close(function (err) {
-          t.notOk(err, 'no error')
-
-          db2.close(function (err) {
-            t.notOk(err, 'no error')
-
-            MemDOWN.destroy('destroy-test', function (err) {
-              t.notOk(err, 'no error')
-
-              MemDOWN.destroy('destroy-test', function (err) {
-                t.ifError(err, 'no destroy error')
-
-                var db3 = new MemDOWN('destroy-test')
-                var db4 = new MemDOWN('other-db')
-
-                db3.get('key', function (err, value) {
-                  t.ok(err, 'key is not there')
-
-                  db4.get('key2', { asBuffer: false }, function (err, value) {
-                    t.notOk(err, 'no error')
-                    t.equal(value, 'value2', 'should have value2')
-                    t.end()
-                  })
-                })
-              })
-            })
-          })
-        })
       })
     })
   })

--- a/test.js
+++ b/test.js
@@ -1,6 +1,6 @@
 var test = require('tape')
 var testCommon = require('abstract-leveldown/testCommon')
-var MemDOWN = require('./')
+var MemDOWN = require('./').default
 // var AbstractIterator = require('./').AbstractIterator
 var testBuffer = require('./testdata_b64')
 var ltgt = require('ltgt')

--- a/test.js
+++ b/test.js
@@ -138,7 +138,7 @@ test('reverse ranges', function (t) {
   var iterator = db.iterator({
     keyAsBuffer: false,
     valueAsBuffer: false,
-    start: 'b',
+    lte: 'b',
     reverse: true
   })
 
@@ -164,7 +164,7 @@ test('delete while iterating', function (t) {
   var iterator = db.iterator({
     keyAsBuffer: false,
     valueAsBuffer: false,
-    start: 'a'
+    gte: 'a'
   })
 
   iterator.next(function (err, key, value) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "target": "es2015",
+    "moduleResolution": "node",
+    "checkJs": true,
+    "allowJs": true
+  }
+}


### PR DESCRIPTION
Closes #84. Also removes `destroy()` and `clearGlobalStore()`.

@MeirionHughes I updated the typings and added ts tests. Had to remove use of the legacy options `start` and `end` in the tests because they don't exist in the typings.