### PR TITLE
Update abstract-leveldown to 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/Level/memdown.git"
   },
   "dependencies": {
-    "abstract-leveldown": "github:level/abstract-leveldown#89a1f48",
+    "abstract-leveldown": "~4.0.0",
     "functional-red-black-tree": "~1.0.1",
     "immediate": "~3.2.3",
     "inherits": "~2.0.1",


### PR DESCRIPTION
Nothing new (we already depended on abstract-leveldown master); will merge once travis is green.

Closes #109.