### PR TITLE
Downgrade broken iphone latest (11.3) to 11.2

### DIFF
--- a/.airtap.yml
+++ b/.airtap.yml
@@ -10,7 +10,8 @@ browsers:
   - name: microsoftedge
     version: latest
   - name: iphone
-    version: latest
+    version: 11.2
+    platform: Mac 10.12
   - name: ipad
     version: latest
   - name: android


### PR DESCRIPTION
Background:

- https://github.com/airtap/browsers/issues/3
- https://github.com/airtap/airtap/issues/152#issuecomment-391771098

This still has the dedup issue though (https://github.com/airtap/airtap/issues/168).