### PR TITLE
Sort keys by type, same as IndexedDB Second Edition

### DIFF
--- a/cmp.js
+++ b/cmp.js
@@ -1,0 +1,71 @@
+'use strict'
+
+var Buffer = require('safe-buffer').Buffer
+var toString = Object.prototype.toString
+
+function cmp (a, b) {
+  // Same logic as https://www.w3.org/TR/IndexedDB-2/#key-construct
+  var ta = type(a)
+  var tb = type(b)
+
+  if (ta !== tb) {
+    // Sort order: number, date, string (lexicographic), binary (bitwise), array (componentwise).
+    if (ta === 'array' && (tb === 'binary' || tb === 'string' || tb === 'date' || tb === 'number')) return 1
+    if (tb === 'array' && (ta === 'binary' || ta === 'string' || ta === 'date' || ta === 'number')) return -1
+    if (ta === 'binary' && (tb === 'string' || tb === 'date' || tb === 'number')) return 1
+    if (tb === 'binary' && (ta === 'string' || ta === 'date' || ta === 'number')) return -1
+    if (ta === 'string' && (tb === 'date' || tb === 'number')) return 1
+    if (tb === 'string' && (ta === 'date' || ta === 'number')) return -1
+    if (ta === 'date' && (tb === 'number')) return 1
+
+    /* istanbul ignore else (because behavior of unsupported types is undefined atm) */
+    if (tb === 'date' && (ta === 'number')) return -1
+  } else {
+    if (ta === 'binary') return bitwise(a, b)
+    if (ta === 'array') return componentwise(a, b)
+  }
+
+  return a < b ? -1 : a > b ? 1 : 0
+}
+
+module.exports = cmp
+
+function bitwise (a, b) {
+  for (var i = 0, l = Math.min(a.length, b.length); i < l; i++) {
+    var c = a[i] - b[i]
+    if (c) return c
+  }
+
+  return a.length - b.length
+}
+
+function componentwise (a, b) {
+  for (var i = 0, l = Math.min(a.length, b.length); i < l; i++) {
+    var c = cmp(a[i], b[i])
+    if (c) return c
+  }
+
+  return a.length - b.length
+}
+
+function type (key) {
+  if (typeof key === 'string') return 'string'
+  if (typeof key === 'number') return 'number'
+  if (Buffer.isBuffer(key)) return 'binary'
+  if (Array.isArray(key)) return 'array'
+
+  var o = toString.call(key)
+
+  if (o === '[object Date]') return 'date'
+  if (o === '[object Int8Array]') return 'binary'
+  if (o === '[object Int16Array]') return 'binary'
+  if (o === '[object Int32Array]') return 'binary'
+  if (o === '[object Uint8Array]') return 'binary'
+  if (o === '[object Uint8ClampedArray]') return 'binary'
+  if (o === '[object Uint16Array]') return 'binary'
+  if (o === '[object Uint32Array]') return 'binary'
+  if (o === '[object Float32Array]') return 'binary'
+  if (o === '[object Float64Array]') return 'binary'
+
+  return o
+}

--- a/memdown.js
+++ b/memdown.js
@@ -4,6 +4,7 @@ var AbstractIterator = require('abstract-leveldown').AbstractIterator
 var ltgt = require('ltgt')
 var createRBT = require('functional-red-black-tree')
 var Buffer = require('safe-buffer').Buffer
+var cmp = require('./cmp')
 
 // In Node, use global.setImmediate. In the browser, use a consistent
 // microtask library to give consistent microtask experience to all browsers
@@ -11,19 +12,19 @@ var setImmediate = require('./immediate')
 var NONE = {}
 
 function gt (value) {
-  return ltgt.compare(value, this._upperBound) > 0
+  return cmp(value, this._upperBound) > 0
 }
 
 function gte (value) {
-  return ltgt.compare(value, this._upperBound) >= 0
+  return cmp(value, this._upperBound) >= 0
 }
 
 function lt (value) {
-  return ltgt.compare(value, this._upperBound) < 0
+  return cmp(value, this._upperBound) < 0
 }
 
 function lte (value) {
-  return ltgt.compare(value, this._upperBound) <= 0
+  return cmp(value, this._upperBound) <= 0
 }
 
 function MemIterator (db, options) {
@@ -121,7 +122,7 @@ function MemDOWN () {
 
   AbstractLevelDOWN.call(this)
 
-  this._store = createRBT(ltgt.compare)
+  this._store = createRBT(cmp)
 }
 
 inherits(MemDOWN, AbstractLevelDOWN)

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "prepublishOnly": "npm run dependency-check"
   },
   "files": [
+    "cmp.js",
     "memdown.js",
     "immediate.js",
     "immediate-browser.js",

--- a/test/key-order-test.js
+++ b/test/key-order-test.js
@@ -1,0 +1,181 @@
+'use strict'
+
+var concat = require('level-concat-iterator')
+
+// Types should sort the same as IndexedDB Second Edition.
+module.exports = function (testCommon) {
+  var test = testCommon.test
+
+  var basicKeys = [
+    // Should sort naturally
+    { type: 'number', value: '-Infinity', key: -Infinity },
+    { type: 'number', value: '2', key: 2 },
+    { type: 'number', value: '10', key: 10 },
+    { type: 'number', value: '+Infinity', key: Infinity },
+
+    // Should sort naturally (by epoch offset)
+    { type: 'date', value: 'new Date(2)', key: new Date(2) },
+    { type: 'date', value: 'new Date(10)', key: new Date(10) },
+
+    // Should sort lexicographically
+    { type: 'string', value: '"10"', key: '10' },
+    { type: 'string', value: '"2"', key: '2' }
+  ]
+
+  var binaryKeys = [
+    // Should sort bitwise
+    { type: 'binary', value: 'Uint8Array.from([0, 2])', key: binary([0, 2]) },
+    { type: 'binary', value: 'Uint8Array.from([1, 1])', key: binary([1, 1]) }
+  ]
+
+  var arrayKeys = [
+    // Should sort componentwise
+    { type: 'array', value: '[100]', key: [100] },
+    { type: 'array', value: '["10"]', key: ['10'] },
+    { type: 'array', value: '["2"]', key: ['2'] }
+  ]
+
+  makeTest('on basic key types', basicKeys, function (verify) {
+    // NOTE: The behavior of nullish range options is undefined *by design*.
+    // verify({ gt: undefined })
+    // verify({ gte: undefined })
+    // verify({ lt: undefined })
+    // verify({ lte: undefined })
+    // verify({ gt: null })
+    // verify({ gte: null })
+    // verify({ lt: null })
+    // verify({ lte: null })
+
+    verify({ gt: -Infinity }, 1)
+    verify({ gte: -Infinity })
+    verify({ gt: +Infinity }, 4)
+    verify({ gte: +Infinity }, 3)
+
+    verify({ lt: -Infinity }, 0, 0)
+    verify({ lte: -Infinity }, 0, 1)
+    verify({ lt: +Infinity }, 0, 3)
+    verify({ lte: +Infinity }, 0, 4)
+
+    verify({ gt: 10 }, 3)
+    verify({ gte: 10 }, 2)
+    verify({ lt: 10 }, 0, 2)
+    verify({ lte: 10 }, 0, 3)
+
+    verify({ gt: new Date(10) }, 6)
+    verify({ gte: new Date(10) }, 5)
+    verify({ lt: new Date(10) }, 0, 5)
+    verify({ lte: new Date(10) }, 0, 6)
+
+    verify({ gte: '' }, 6)
+    verify({ gt: '' }, 6)
+    verify({ lt: '' }, 0, 6)
+    verify({ lte: '' }, 0, 6)
+
+    verify({ gt: '10' }, 7)
+    verify({ gte: '10' }, 6)
+    verify({ lt: '10' }, 0, 6)
+    verify({ lte: '10' }, 0, 7)
+
+    verify({ gt: '2' }, 0, 0)
+    verify({ gte: '2' }, -1)
+    verify({ lt: '2' }, 0, -1)
+    verify({ lte: '2' })
+  })
+
+  makeTest('on string keys only', basicKeys.filter(matchType('string')), function (verify) {
+    verify({ gt: '' })
+    verify({ gte: '' })
+    verify({ lt: '' }, 0, 0)
+    verify({ lte: '' }, 0, 0)
+  })
+
+  makeTest('on binary keys', basicKeys.concat(binaryKeys), function (verify) {
+    verify({ gt: binary([]) }, -2)
+    verify({ gte: binary([]) }, -2)
+    verify({ lt: binary([]) }, 0, -2)
+    verify({ lte: binary([]) }, 0, -2)
+  })
+
+  makeTest('on array keys', basicKeys.concat(arrayKeys), function (verify) {
+    verify({ gt: [] }, -3)
+    verify({ gte: [] }, -3)
+    verify({ lt: [] }, 0, -3)
+    verify({ lte: [] }, 0, -3)
+  })
+
+  makeTest('on all key types', basicKeys.concat(binaryKeys).concat(arrayKeys))
+
+  function makeTest (name, input, fn) {
+    var prefix = 'native order (' + name + '): '
+    var db
+
+    test(prefix + 'open', function (t) {
+      db = testCommon.factory()
+      db.open(t.end.bind(t))
+    })
+
+    test(prefix + 'prepare', function (t) {
+      db.batch(input.map(function (item) {
+        return { type: 'put', key: item.key, value: item.value }
+      }), t.end.bind(t))
+    })
+
+    function verify (options, begin, end) {
+      test(prefix + humanRange(options), function (t) {
+        t.plan(2)
+
+        options.valueAsBuffer = false
+        concat(db.iterator(options), function (err, result) {
+          t.ifError(err, 'no concat error')
+          t.same(result.map(getValue), input.slice(begin, end).map(getValue))
+        })
+      })
+    }
+
+    verify({})
+    if (fn) fn(verify)
+
+    test(prefix + 'close', function (t) {
+      db.close(t.end.bind(t))
+    })
+  }
+}
+
+function matchType (type) {
+  return function (item) {
+    return item.type === type
+  }
+}
+
+function getValue (kv) {
+  return kv.value
+}
+
+// Replacement for TypedArray.from()
+function binary (bytes) {
+  var arr = new Uint8Array(bytes.length)
+  for (var i = 0; i < bytes.length; i++) arr[i] = bytes[i]
+  return arr
+}
+
+function humanRange (options) {
+  var a = []
+
+  ;['gt', 'gte', 'lt', 'lte'].forEach(function (opt) {
+    if (options.hasOwnProperty(opt)) {
+      var target = options[opt]
+
+      if (typeof target === 'string' || Array.isArray(target)) {
+        target = JSON.stringify(target)
+      } else if (Object.prototype.toString.call(target) === '[object Date]') {
+        target = 'new Date(' + target.valueOf() + ')'
+      } else if (Object.prototype.toString.call(target) === '[object Uint8Array]') {
+        target = 'Uint8Array.from([' + target + '])'
+      }
+
+      a.push(opt + ': ' + target)
+    }
+  })
+
+  return a.length ? a.join(', ') : 'all'
+}

--- a/test/key-type-test.js
+++ b/test/key-type-test.js
@@ -1,0 +1,110 @@
+'use strict'
+
+var concat = require('level-concat-iterator')
+var bytes = [0, 127]
+
+// Test all supported key types by asserting that output is the same as input.
+// Same as IndexedDB Second Edition, except that memdown returns views as-is,
+// while IDB returns ArrayBuffers. This is a smoke test because memdown does not
+// convert inputs in any way, so the assertions are not far from key === key.
+var types = [
+  { type: 'number', key: -20 },
+  { type: '+Infinity', key: Infinity },
+  { type: '-Infinity', key: -Infinity },
+  { type: 'string', key: 'test' },
+  { type: 'Date', ctor: true, key: new Date() },
+  { type: 'Array', ctor: true, key: [0, '1'] },
+  { type: 'ArrayBuffer', ctor: true, key: ta(Buffer).buffer },
+  { type: 'Uint8Array', ctor: true, createKey: ta },
+  { name: 'Buffer', type: 'Uint8Array', ctor: true, key: ta(Buffer) },
+  { type: 'Int8Array', ctor: true, allowFailure: true, createKey: ta },
+  { type: 'Uint8ClampedArray', ctor: true, allowFailure: true, createKey: ta },
+  { type: 'Int16Array', ctor: true, allowFailure: true, createKey: ta },
+  { type: 'Uint16Array', ctor: true, allowFailure: true, createKey: ta },
+  { type: 'Int32Array', ctor: true, allowFailure: true, createKey: ta },
+  { type: 'Uint32Array', ctor: true, allowFailure: true, createKey: ta },
+  { type: 'Float32Array', ctor: true, allowFailure: true, createKey: ta },
+  { type: 'Float64Array', ctor: true, allowFailure: true, createKey: ta }
+]
+
+module.exports = function (testCommon) {
+  var db
+  var test = testCommon.test
+
+  test('setUp', testCommon.setUp)
+  test('open', function (t) {
+    db = testCommon.factory()
+    db.open(t.end.bind(t))
+  })
+
+  types.forEach(function (item) {
+    var testName = item.name || item.type
+
+    test('key type: ' + testName, function (t) {
+      var Constructor = item.ctor ? global[item.type] : null
+      var skip = item.allowFailure ? 'pass' : 'fail'
+      var input = item.key
+
+      if (item.ctor && !Constructor) {
+        t[skip]('constructor is undefined in this environment')
+        return t.end()
+      }
+
+      if (item.createKey) {
+        try {
+          input = item.createKey(Constructor)
+        } catch (err) {
+          t[skip]('constructor is not spec-compliant in this environment')
+          return t.end()
+        }
+      }
+
+      db.put(input, testName, function (err) {
+        t.ifError(err, 'no put error')
+
+        db.get(input, { asBuffer: false }, function (err, value) {
+          t.ifError(err, 'no get error')
+          t.same(value, testName, 'correct value')
+
+          var it = db.iterator({ keyAsBuffer: false, valueAsBuffer: false })
+
+          concat(it, function (err, entries) {
+            t.ifError(err, 'no iterator error')
+            t.is(entries.length, 1, '1 entry')
+
+            var key = entries[0].key
+            var value = entries[0].value
+
+            if (Constructor) {
+              var expected = '[object ' + item.type + ']'
+              var actual = Object.prototype.toString.call(key)
+
+              t.is(actual, expected, 'prototype')
+              t.ok(key instanceof Constructor, 'key is instanceof ' + item.type)
+              t.same(key, input, 'correct key')
+            } else {
+              t.is(key, input, 'correct key')
+            }
+
+            t.same(value, testName, 'correct value')
+
+            db.del(input, function (err) {
+              t.ifError(err, 'no del error')
+              t.end()
+            })
+          })
+        })
+      })
+    })
+  })
+
+  test('close', function (t) { db.close(t.end.bind(t)) })
+  test('tearDown', testCommon.tearDown)
+}
+
+// Replacement for TypedArray.from(bytes)
+function ta (TypedArray) {
+  var arr = new TypedArray(bytes.length)
+  for (var i = 0; i < bytes.length; i++) arr[i] = bytes[i]
+  return arr
+}


### PR DESCRIPTION
NB. This has a performance impact on all operations (any type of read or write) but I'm not doing benchmarks yet, because I strongly believe we must first make a collective decision on the desired behavior, then optimize for that. I'm opening a separate ticket for that discussion.

---

As for this PR: it's feature-complete. I wrote the comparator by following IDB specs and copied tests from `level-js` to verify it.